### PR TITLE
fix(release): migrate to module.exports and streamline plugin configuration

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,70 +1,24 @@
-export const extendConfig = [
-	'semantic-release-npm-github-publish',
-];
-export const branches = [
-	{ name: 'main', channel: 'latest', range: 'main' },
-];
-export const plugins = [
-	[
-		"@semantic-release/commit-analyzer",
-		{
-			"releaseRules": [
-				{
-					"type": "build",
-					"release": "patch"
-				},
-				{
-					"type": "ci",
-					"release": "patch"
-				},
-				{
-					"type": "chore",
-					"release": "patch"
-				},
-				{
-					"type": "docs",
-					"release": "patch"
-				},
-				{
-					"type": "refactor",
-					"release": "patch"
-				},
-				{
-					"type": "style",
-					"release": "patch"
-				},
-				{
-					"type": "test",
-					"release": "patch"
-				},
-				{
-					"type": "feat",
-					"release": "minor"
-				},
-				{
-					"type": "fix",
-					"release": "patch"
-				},
-				{
-					"type": "perf",
-					"release": "patch"
-				},
-				{
-					"type": "BREAKING CHANGE",
-					"release": "major"
-				}
-			]
-		}
+module.exports = {
+	branches: [
+		'main'
 	],
-	'@semantic-release/release-notes-generator',
-	'@semantic-release/changelog',
-	'@semantic-release/npm',
-	[
-		'@semantic-release/git',
-		{
-			assets: ['package.json', 'pnpm-lock.yaml', 'CHANGELOG.md', 'README.md', 'dist/**', 'docs/**'],
-			message: 'release(version): Release ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
-		}
-	],
-	"@semantic-release/github",
-];
+	plugins: [
+		'@semantic-release/commit-analyzer',
+		'@semantic-release/release-notes-generator',
+		[
+			'@semantic-release/changelog',
+			{
+				changelogFile: 'CHANGELOG.md'
+			}
+		],
+		"@semantic-release/npm",
+		'@semantic-release/github',
+		[
+			'@semantic-release/git',
+			{
+				assets: ['package.json', 'package-lock.json', 'CHANGELOG.md', 'README.md', 'dist/**', 'docs/**'],
+				message: 'chore(release): set `package.json` to ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
+			}
+		]
+	]
+}


### PR DESCRIPTION
This pull request includes a significant refactor of the `release.config.js` file to simplify and update the release configuration. The most important changes include switching from ES module syntax to CommonJS, updating the list of plugins, and modifying the assets and commit message for the `@semantic-release/git` plugin.

Configuration updates:

* [`release.config.js`](diffhunk://#diff-ac88fd8e5da48b4c325de01dc00bc9609325e9bdb489c5a1abc781d538a1579eL1-L70): Changed from ES module syntax to CommonJS by replacing `export` statements with `module.exports`.

Plugin updates:

* [`release.config.js`](diffhunk://#diff-ac88fd8e5da48b4c325de01dc00bc9609325e9bdb489c5a1abc781d538a1579eL1-L70): Updated the list of plugins to include `@semantic-release/commit-analyzer`, `@semantic-release/release-notes-generator`, `@semantic-release/changelog`, `@semantic-release/npm`, `@semantic-release/github`, and `@semantic-release/git`. Removed the `semantic-release-npm-github-publish` plugin.

Asset and commit message updates:

* [`release.config.js`](diffhunk://#diff-ac88fd8e5da48b4c325de01dc00bc9609325e9bdb489c5a1abc781d538a1579eL1-L70): Modified the assets list in the `@semantic-release/git` plugin to include `package-lock.json` instead of `pnpm-lock.yaml`. Updated the commit message format to `chore(release): set This pull request includes a significant refactor of the `release.config.js` file to simplify and update the release configuration. The most important changes include switching from ES module syntax to CommonJS, updating the list of plugins, and modifying the assets and commit message for the `@semantic-release/git` plugin.

Configuration updates:

* [`release.config.js`](diffhunk://#diff-ac88fd8e5da48b4c325de01dc00bc9609325e9bdb489c5a1abc781d538a1579eL1-L70): Changed from ES module syntax to CommonJS by replacing `export` statements with `module.exports`.

Plugin updates:

* [`release.config.js`](diffhunk://#diff-ac88fd8e5da48b4c325de01dc00bc9609325e9bdb489c5a1abc781d538a1579eL1-L70): Updated the list of plugins to include `@semantic-release/commit-analyzer`, `@semantic-release/release-notes-generator`, `@semantic-release/changelog`, `@semantic-release/npm`, `@semantic-release/github`, and `@semantic-release/git`. Removed the `semantic-release-npm-github-publish` plugin.

Asset and commit message updates:

package.jsonThis pull request includes a significant refactor of the `release.config.js` file to simplify and update the release configuration. The most important changes include switching from ES module syntax to CommonJS, updating the list of plugins, and modifying the assets and commit message for the `@semantic-release/git` plugin.

Configuration updates:

* [`release.config.js`](diffhunk://#diff-ac88fd8e5da48b4c325de01dc00bc9609325e9bdb489c5a1abc781d538a1579eL1-L70): Changed from ES module syntax to CommonJS by replacing `export` statements with `module.exports`.

Plugin updates:

* [`release.config.js`](diffhunk://#diff-ac88fd8e5da48b4c325de01dc00bc9609325e9bdb489c5a1abc781d538a1579eL1-L70): Updated the list of plugins to include `@semantic-release/commit-analyzer`, `@semantic-release/release-notes-generator`, `@semantic-release/changelog`, `@semantic-release/npm`, `@semantic-release/github`, and `@semantic-release/git`. Removed the `semantic-release-npm-github-publish` plugin.

Asset and commit message updates:

 to \${nextRelease.version} [skip ci]\n\n\${nextRelease.notes}`.